### PR TITLE
Pleo 001

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+    presets: [
+      [
+        '@babel/preset-env',
+        {
+          targets: {
+            node: 'current',
+          },
+        },
+      ],
+    ],
+  };

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -22,7 +22,7 @@ import {
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime } from "../utils/format-date";
+import { formatDateTime, formatDateTimeLocal } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 
@@ -123,8 +123,8 @@ function TimeAndLocation({ launch }) {
             Launch Date
           </Box>
         </StatLabel>
-        <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
+        <StatNumber fontSize={["md", "xl"]} title={formatDateTime(launch.launch_date_local)}>
+          {formatDateTimeLocal(launch.launch_date_local)}
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -18,3 +18,18 @@ export function formatDateTime(timestamp) {
     timeZoneName: "short",
   }).format(new Date(timestamp));
 }
+
+export function formatDateTimeLocal(local) {
+  const match = local.match(/([T0-9-:]*)([+-][:0-9]*)/);
+  const datetime = match.length >= 1 ? match[1] : local;
+  const offset = match.length >= 2 ? ` UTC${match[2]}` : '';
+  const dateString = new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    second: "numeric"
+  }).format(new Date(datetime));
+  return `${dateString}${offset}`;
+}

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -20,9 +20,10 @@ export function formatDateTime(timestamp) {
 }
 
 export function formatDateTimeLocal(local) {
-  const match = local.match(/([T0-9-:]*)([+-][:0-9]*)/);
-  const datetime = match.length >= 1 ? match[1] : local;
-  const offset = match.length >= 2 ? ` UTC${match[2]}` : '';
+  const match = local.match(/([0-9-]*T[0-9:]*)([+-][:0-9]*)/);
+  const useMatch = match && match.length === 3;
+  const datetime = useMatch ? match[1] : local;
+  const offset = useMatch ? ` UTC${match[2]}` : '';
   const dateString = new Intl.DateTimeFormat("en-US", {
     year: "numeric",
     month: "long",

--- a/src/utils/format-date.test.js
+++ b/src/utils/format-date.test.js
@@ -1,0 +1,13 @@
+import { formatDateTimeLocal } from "./format-date";
+
+describe('format-date', () => {
+    it('should give expect output for local date with no offset', () => {
+      expect(formatDateTimeLocal('2021-10-15T22:00:00')).toEqual('October 15, 2021, 10:00:00 PM');
+    });
+    it('should give expect output for local date with +ve offset', () => {
+      expect(formatDateTimeLocal('2021-10-15T22:00:00+03:00')).toEqual('October 15, 2021, 10:00:00 PM UTC+03:00');
+    });
+    it('should give expect output for local date with -ve offset', () => {
+      expect(formatDateTimeLocal('2021-10-15T22:00:00-03:00')).toEqual('October 15, 2021, 10:00:00 PM UTC-03:00');
+    });
+  })


### PR DESCRIPTION
Task 1 : fix launch datetime on the launch details page to show date time in local timezone of the launch site.

* new function formatDateTimeLocal in 'format-date'
* function strips timezone from input local datetime string assuming format provided by SpaceX api
* date string stripped of timezone can be used to construct date object without conversion of yyyy-mm-dd:hh-mm
* date string constructed in same format as formatDateTime in 'format-date'
* additional UTC offset added to end of string to denote offset
* timezone not present in spaceX api data, so timezone cannot be assumed based on UTC offset, since that is a one-to-many relationship
* NOTE babel.config.js added to allow modules, such as 'format-date' to imported for jest tests
* unit test added for formatDateTimeLocal to check proper output based on +ve, -ve or missing timezone offsets.