### PR TITLE
Pleo 003 - Impress Us

### DIFF
--- a/FILTERS.md
+++ b/FILTERS.md
@@ -1,0 +1,113 @@
+# Filtering
+
+We will implement some basic filtering on the launches page. In the future this can be extended with more filters, and filtering could also be added to the launch-pads page, or any other pages we might add. The types of filtering we can do are limited and informed by the features of the SpaceX API.
+
+## SpaceX API filtering
+
+The launches are retrieved via the following endpoint
+
+```https://api.spacexdata.com/v3/launches```
+
+The filter parameters availabled are documented here:
+
+https://docs.spacexdata.com/?version=latest#bc65ba60-decf-4289-bb04-4ca9df01b9c1
+
+There are nearly 50 filters, many of which would not be appropriate for a simple search mechanism on the launches page. When searching, it makes sense for the parameters of the search to be presented in the results of the search, so let's start with what is currently displayed for each launch item and work back from there to identify the filters.
+
+## Launch Item Fields
+
+* Launch Success
+* Rocket Name
+* Launch Site Name
+* Mission Name
+* Launch Date
+
+### Launch Success
+
+This is a simple binary choice and could be represented by a checkbox or toggle control.
+
+Query String Param | Values
+---|---
+launch_success | true OR false
+
+### Rocket Name
+
+There is a field to search by name, but the precise name must be known and entered for it to work. There is no "like" partial string text search. It would be better to have a select pulldown of rockets to choose from. Each rocket has a unique id, which can be used for our launches filter.
+
+Query String Param | Values | Example
+---|---|---
+rocket_id | (id string) | falconheavy
+
+To retrieve the list of id/name parts for each rocket we will use the following endpoint.
+
+```https://api.spacexdata.com/v3/rockets```
+
+The API offers no mechanism for mapping the results, so all fields will be returned in the response. The fields we are interested in for our pulldown are:
+
+* rocket_name
+* rocket_id
+
+Currently there are only 4 rockets, so pulling all these down is not prohibitive. Ideally we would have our own API that could cache the configuration needed for the filters throughout the whole application, but this will suffice for our proof of concept.
+
+### Launch Site Name
+
+The same principals we applied to the rocket name search apply here.
+
+Query String Param | Values | Example
+---|---|---
+site_id | (id string) | ksc_lc_39a
+
+To retrieve the list of id/name parts for each launch site we will use the following endpoint, which is the same one used on the launch-pads page.
+
+```https://api.spacexdata.com/v3/launchpads```
+
+The fields we need are:
+
+* name
+* site_id
+
+There is also a "site_name_long", but this would be too long for a pulldown select box. Perhaps it could be used in the filter summary (see below)
+
+This endpoint is already 
+
+### Mission Name
+
+For the purposes of this proof of concept, we will not be adding this filter. There is a missions endpoint which we could use in the same way as the others, but since we don't have a way of setting the fields we want returned, or a single endpoint to call to get the data we need from multiple sources, this approach will not scale well and will result in ever longer initialisation times for the application.
+
+### Launch Date
+
+The filtering offered by the launches endpoint is simple and does not offer a way to filter by date ranges. However, there is a year filter, which might be useful. For now we will simply create the select pulldown for this manually, from 2006 to the final year in this historical data set: 2020.
+
+The first launch year can be found like so:
+
+```https://api.spacexdata.com/v3/launches?sort=launch_year&order=asc&limit=1```
+
+and the last like so:
+
+```https://api.spacexdata.com/v3/launches?sort=launch_year&order=desc&limit=1```
+
+
+## Filter Summary
+
+We are keeping the filter controls simple and visible, rather than in a hidden panel or modal. This will serve as a visual aid to the user so they know what current filters are applied. It might also be useful to have a simple summary, where selected:
+
+* rocket name
+* full launch site name
+
+## Ordering
+
+The only ordering that seems to be useful is on launch date. We will make a most recent / oldest toggle sort control using the following sort params
+
+oldest ```?sort=launch_date_utc&order=asc```
+
+most recent ```?sort=launch_date_utc&order=desc```
+
+
+
+## Paging
+
+The results should continue to be paged using the useSpaceXPaginated() hook.
+
+## Implementation
+
+The final endpoint urls are constructed in the use-space-x hooks which wrap useSWR. The filters need to be added to this hook as options. Special care needs to be taken to ensure the order of filters is always consistent so we can take advantage of SWR caching.

--- a/src/components/launch-item.js
+++ b/src/components/launch-item.js
@@ -1,8 +1,8 @@
 import React from "react";
-import { Badge, Box, Image, Text, Flex } from "@chakra-ui/react";
+import { Badge, Box, Image, Text, Flex, Tooltip } from "@chakra-ui/react";
 import { format as timeAgo } from "timeago.js";
 import { Link } from "react-router-dom";
-import { formatDate } from "../utils/format-date";
+import { formatDate, formatDateTimeLocal } from "../utils/format-date";
 import { useSpaceX } from "../utils/use-space-x";
 import Error from "./error"; // might need a different error markup here
 import Favourite from './favourite';
@@ -99,7 +99,9 @@ export function LaunchItem({ launch }) {
             {launch.mission_name}
           </Box>
           {launch.launch_date_utc && <Flex>
-            <Text fontSize="sm">{formatDate(launch.launch_date_utc)} </Text>
+            <Tooltip label={formatDate(launch.launch_date_local)}>
+              <Text fontSize="sm">{formatDateTimeLocal(launch.launch_date_local)} </Text>
+            </Tooltip>
             <Text color="gray.500" ml="2" fontSize="sm">
               {timeAgo(launch.launch_date_utc)}
             </Text>

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,6 +19,7 @@ import {
   Stack,
   AspectRatio,
   StatGroup,
+  Tooltip
 } from "@chakra-ui/react";
 
 import { useSpaceX } from "../utils/use-space-x";
@@ -125,9 +126,11 @@ function TimeAndLocation({ launch }) {
             Launch Date
           </Box>
         </StatLabel>
-        <StatNumber fontSize={["md", "xl"]} title={formatDateTime(launch.launch_date_local)}>
-          {formatDateTimeLocal(launch.launch_date_local)}
-        </StatNumber>
+        <Tooltip label={formatDateTime(launch.launch_date_local)}>
+          <StatNumber fontSize={["md", "xl"]}>
+            {formatDateTimeLocal(launch.launch_date_local)}
+          </StatNumber>
+        </Tooltip>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>
       <Stat>

--- a/src/components/launches.js
+++ b/src/components/launches.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { SimpleGrid, Flex, Select, FormControl, FormLabel } from "@chakra-ui/react";
+import { SimpleGrid, Flex, Select, FormControl, FormLabel, Switch } from "@chakra-ui/react";
 
 import { useSpaceX, useSpaceXPaginated } from "../utils/use-space-x";
 import Error from "./error";
@@ -8,64 +8,106 @@ import LoadMoreButton from "./load-more-button";
 
 import { FavouriteLaunches } from './favourite-launches';
 import { LaunchItem } from './launch-item';
+import { updateFilter } from '../utils/update-filter';
 
 const PAGE_SIZE = 12;
 
-function RocketFilter({onChange}) {
-  
-  const { data, error } = useSpaceX(`/rockets`);
+function SelectFilter(props) {
+  const { param, label, labelField, data, error, onChange } = props;
+  const [ value, setValue ] = useState("All");
 
-  const RocketFilterWrapper = (props) => {
+  const onSelectChange = (event) => {
+      setValue(event.target.value);
+      onChange(event.target.value);
+  }
+
+  const SelectFilterWrapper = (props) => {
     const { children } = props;
-    return <FormControl id="rocket">
-        <Flex w="32" direction="horizontal" padding="15">
-            <FormLabel>Rocket</FormLabel>
-            {children}
-        </Flex>
+
+    return <FormControl marginLeft="30px" display="flex" alignItems="center" id={param} w="300px">
+          <FormLabel style={{whiteSpace: "nowrap"}}>{label}</FormLabel>
+          {children}
       </FormControl>
   }
 
   if (error) {
-    return <RocketFilterWrapper>
+    return <SelectFilterWrapper>
       <Select placeholder={error} disabled></Select>
-    </RocketFilterWrapper>
+    </SelectFilterWrapper>
   }
 
   if (!data) {
-    return <RocketFilterWrapper>
-      <Select placeholder="Rocket" disabled></Select>
-    </RocketFilterWrapper>
+    return <SelectFilterWrapper>
+      <Select disabled></Select>
+    </SelectFilterWrapper>
   }
 
-  return <RocketFilterWrapper>
-    <Select placeholder="All" onChange={event => onChange(event.currentTarget.value)}>
-      {data.map(r => (<option value={r.rocket_id} key={r.id}>{r.rocket_name}</option>))}
+  return <SelectFilterWrapper>
+    <Select placeholder="All" value={value} onChange={onSelectChange}>
+      {data.map(r => (<option value={r[param]} key={r[param]}>{r[labelField]}</option>))}
     </Select>
-  </RocketFilterWrapper>
+  </SelectFilterWrapper>
+}
+
+function RocketFilter({onChange}) {
+  const { data, error } = useSpaceX("/rockets");
+  return  <SelectFilter 
+  param="rocket_id"
+    label="Rocket"
+    labelField="rocket_name"
+    data={data}
+    error={error}
+    onChange={onChange}/>
+}
+
+function LaunchSiteFilter({onChange}) {
+  const { data, error } = useSpaceX("/launchpads");
+  return  <SelectFilter 
+    param="site_id"
+    label="Launch Site"
+    labelField="name"
+    data={data}
+    error={error}
+    onChange={onChange}/>
+}
+
+function LaunchYearFilter({onChange}) {
+  const start = 2006;
+  const years = Array.from(Array(15).keys()).map(x => ({launch_year: `${x + start}`, name: `${x + start}`}));
+  const error = null;
+  return  <SelectFilter 
+    param="launch_year"
+    label="Launch Year"
+    labelField="name"
+    data={years}
+    error={error}
+    onChange={onChange}/>
+}
+
+function OrderSwitch({checked, onChange}) {
+  const onChecked = event => onChange(event.target.checked);
+  
+  return <FormControl marginLeft="30px" display="flex" alignItems="center">
+    <FormLabel htmlFor="order" mb="0">
+      Most Recent?
+    </FormLabel>
+    <Switch id="order" isChecked={checked} onChange={onChecked} />
+  </FormControl>
 }
 
 export default function Launches() {
   const [ filters, setFilters ] = useState({});
+  const [ desc, setDesc ] = useState(true);
   const { data, error, isValidating, setSize, size } = useSpaceXPaginated(
     "/launches/past",
     {
       limit: PAGE_SIZE,
-      order: "desc",
+      order: desc ? "desc" : "asc",
       sort: "launch_date_utc",
       ...filters
     }
   );
   
-  const onRocketFilter = (rocket_id) => {
-    console.log(rocket_id);
-    if (rocket_id === 'all') {
-      setFilters({});
-    }
-    else {
-      setFilters({rocket_id: rocket_id});
-    }
-  }
-
   return (
     <div>
       <Flex direction="horizontal" w="100vw" justify="space-between" align="center" paddingRight="40px">
@@ -74,8 +116,13 @@ export default function Launches() {
         />
         <FavouriteLaunches/>
       </Flex>
-      <Flex direction="horizontal" w="100vw" align="center">
-        <RocketFilter onChange={onRocketFilter}/>
+      <Flex direction="horizontal" w="100vw" alignItems="center" justify="space-between">
+        <Flex direction="horizontal" alignItems="center">
+          <RocketFilter onChange={value => updateFilter("rocket_id", value, setFilters)}/>
+          <LaunchSiteFilter onChange={value => updateFilter("site_id", value, setFilters)}/>
+          <LaunchYearFilter onChange={value => updateFilter("launch_year", value, setFilters)}/>
+        </Flex>
+        <OrderSwitch checked={desc} onChange={setDesc}/>
       </Flex>
       <SimpleGrid m={[2, null, 6]} minChildWidth="350px" spacing="4">
         {error && <Error />}

--- a/src/components/launches.js
+++ b/src/components/launches.js
@@ -1,7 +1,7 @@
-import React from "react";
-import { SimpleGrid, Flex } from "@chakra-ui/react";
+import React, { useState } from "react";
+import { SimpleGrid, Flex, Select, FormControl, FormLabel } from "@chakra-ui/react";
 
-import { useSpaceXPaginated } from "../utils/use-space-x";
+import { useSpaceX, useSpaceXPaginated } from "../utils/use-space-x";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import LoadMoreButton from "./load-more-button";
@@ -11,15 +11,61 @@ import { LaunchItem } from './launch-item';
 
 const PAGE_SIZE = 12;
 
+function RocketFilter({onChange}) {
+  
+  const { data, error } = useSpaceX(`/rockets`);
+
+  const RocketFilterWrapper = (props) => {
+    const { children } = props;
+    return <FormControl id="rocket">
+        <Flex w="32" direction="horizontal" padding="15">
+            <FormLabel>Rocket</FormLabel>
+            {children}
+        </Flex>
+      </FormControl>
+  }
+
+  if (error) {
+    return <RocketFilterWrapper>
+      <Select placeholder={error} disabled></Select>
+    </RocketFilterWrapper>
+  }
+
+  if (!data) {
+    return <RocketFilterWrapper>
+      <Select placeholder="Rocket" disabled></Select>
+    </RocketFilterWrapper>
+  }
+
+  return <RocketFilterWrapper>
+    <Select placeholder="All" onChange={event => onChange(event.currentTarget.value)}>
+      {data.map(r => (<option value={r.rocket_id} key={r.id}>{r.rocket_name}</option>))}
+    </Select>
+  </RocketFilterWrapper>
+}
+
 export default function Launches() {
+  const [ filters, setFilters ] = useState({});
   const { data, error, isValidating, setSize, size } = useSpaceXPaginated(
     "/launches/past",
     {
       limit: PAGE_SIZE,
       order: "desc",
       sort: "launch_date_utc",
+      ...filters
     }
   );
+  
+  const onRocketFilter = (rocket_id) => {
+    console.log(rocket_id);
+    if (rocket_id === 'all') {
+      setFilters({});
+    }
+    else {
+      setFilters({rocket_id: rocket_id});
+    }
+  }
+
   return (
     <div>
       <Flex direction="horizontal" w="100vw" justify="space-between" align="center" paddingRight="40px">
@@ -27,6 +73,9 @@ export default function Launches() {
           items={[{ label: "Home", to: "/" }, { label: "Launches" }]}
         />
         <FavouriteLaunches/>
+      </Flex>
+      <Flex direction="horizontal" w="100vw" align="center">
+        <RocketFilter onChange={onRocketFilter}/>
       </Flex>
       <SimpleGrid m={[2, null, 6]} minChildWidth="350px" spacing="4">
         {error && <Error />}

--- a/src/utils/update-filter.js
+++ b/src/utils/update-filter.js
@@ -1,0 +1,10 @@
+export const updateFilter = (key, value, set) => {
+  if (value === undefined || value == null || value === "") {
+    set(current => {
+      const { [key]: _, ...rest } = current;
+      return rest;
+    });
+  } else {
+    set(current => ({ ...current, [key]: value }));
+  }
+};

--- a/src/utils/update-filter.test.js
+++ b/src/utils/update-filter.test.js
@@ -1,0 +1,23 @@
+import { updateFilter } from "./update-filter";
+
+let filters = {}
+const set = fn => filters = fn(filters);
+
+describe('updateFilter', () => {
+    it('should set a filter value by key', () => {
+      updateFilter('foo', 1, set);
+      expect(filters).toEqual({foo: 1});
+    });
+    it('should set another filter value by key', () => {
+      updateFilter('bar', 2, set);
+      expect(filters).toEqual({foo: 1, bar: 2});
+    });
+    it('should remove a filter value by key', () => {
+      updateFilter('foo', undefined, set);
+      expect(filters).toEqual({bar: 2});
+    });
+    it('should change a filter value by key', () => {
+      updateFilter('bar', 4, set);
+      expect(filters).toEqual({bar: 4});
+    });
+});


### PR DESCRIPTION
* Added basic filtering and sorting to the launches page
* See Design in ./FILTERS.md
* Would like to spend more time ensuring calls to spaceX have consistent ordering of query string parameters to ensure caching is used in SWR
* scope for refactor of filters into other files for reuse on other pages
* would like it to be easy to add filtering to future pages showing different content
* added helper util "updateFilter" which, along with the SelectFilter component, and possibly a "TextFilter" component for text search, should be straightforward to configure in a similar way as seen here on the launches page.
* would like to add a dark mode option!
* would like to spend more time checking responsiveness for mobile (favourites slide-in would be better full screen on mobile)